### PR TITLE
docs: add AI & Agents section with MCP, skill, and integration guides

### DIFF
--- a/developers/ai/garden-skill.mdx
+++ b/developers/ai/garden-skill.mdx
@@ -1,0 +1,321 @@
+---
+title: "Garden Swap Skill"
+description: "Perform cross-chain swaps with a plain-language request in Claude Code"
+---
+
+The **Garden Swap Skill** is a Claude Code skill that handles the full swap lifecycle — from quoting to confirmation — by responding to a natural-language swap request. It connects to the [Garden MCP server](/developers/ai/mcp), derives wallet addresses from your private key, executes the on-chain transactions, and polls for completion.
+
+One sentence is enough to start a swap:
+
+> *"Swap 0.001 BTC to wBTC"*
+> *"Bridge my wBTC to Bitcoin"*
+> *"Swap 0.5 SOL to BTC on Garden"*
+
+---
+
+## Compatibility
+
+The Garden Swap Skill's **auto-loading and Keychain credential management** are Claude Code-specific. However, the underlying signing scripts and MCP server are platform-agnostic — any terminal-based AI tool that supports both MCP and shell command execution can replicate the full automated swap flow with a small amount of manual setup.
+
+| Tool | Automated swap flow | How |
+|---|---|---|
+| **Claude Code** | Native | Skill auto-loads; Keychain manages the private key |
+| **Gemini CLI** | Yes, with manual setup | MCP + Bun scripts + `GARDEN_PRIVATE_KEY` env var |
+| **Codex CLI** | Yes, with manual setup | MCP + Bun scripts + `GARDEN_PRIVATE_KEY` env var |
+| Claude Desktop | MCP only | No shell execution; sign via external wallet |
+| Cursor / Windsurf | MCP only | No shell execution in chat; sign via external wallet |
+| ChatGPT Desktop | MCP only | No shell execution; sign via external wallet |
+
+---
+
+## Using on Gemini CLI
+
+Gemini CLI supports MCP servers and can execute shell commands, so the full quote → sign → initiate → poll flow works. The difference from Claude Code is that you provide the private key as an environment variable instead of Keychain, and you load the skill instructions manually at the start of the session.
+
+**Prerequisites**
+
+- [Gemini CLI](https://github.com/google-gemini/gemini-cli) installed and authenticated
+- [Bun](https://bun.sh) runtime — `curl -fsSL https://bun.sh/install | bash`
+- Garden MCP server connected (see [Connect your AI client → Gemini CLI](/developers/ai/mcp#connect-your-ai-client))
+
+<Steps>
+  <Step title="Clone and install the signing scripts">
+    ```bash
+    git clone https://github.com/gardenfi/garden-agent.git
+    cd garden-agent/garden-skill && bun install
+    ```
+  </Step>
+  <Step title="Store your private key in macOS Keychain">
+    Run the setup script once — it captures your key with hidden input and saves it to macOS Keychain, identical to Claude Code's setup:
+
+    ```bash
+    bash ~/garden-agent/garden-skill/scripts/setup-credentials.sh
+    ```
+
+    The key is stored under the service name `garden-pk`. Gemini will retrieve it at swap time using the same `security` command the skill uses internally:
+
+    ```bash
+    security find-generic-password -a garden -s garden-pk -w
+    ```
+
+    No environment variable needed.
+  </Step>
+  <Step title="Start a session with the skill instructions">
+    Pass the `SKILL.md` as a system prompt so Gemini follows the same swap flow:
+
+    ```bash
+    gemini --system-prompt "$(cat ~/garden-agent/garden-skill/SKILL.md)"
+    ```
+
+    If your version of Gemini CLI uses a different flag (e.g., `-s`), consult `gemini --help`.
+  </Step>
+  <Step title="Describe your swap">
+    ```
+    swap 0.001 wBTC to BTC
+    swap 0.5 SOL to BTC on Garden
+    ```
+
+    Gemini will call the Garden MCP tools for quotes and orders, then execute the Bun signing scripts from `$GARDEN_SCRIPTS_DIR` to initiate on-chain.
+  </Step>
+</Steps>
+
+---
+
+## Using on Codex CLI
+
+Codex CLI is purpose-built for running code and shell commands, so it pairs well with the Garden signing scripts. Setup is nearly identical to Gemini CLI.
+
+**Prerequisites**
+
+- [Codex CLI](https://github.com/openai/codex) installed and authenticated
+- [Bun](https://bun.sh) runtime — `curl -fsSL https://bun.sh/install | bash`
+- Garden MCP server connected (see [Connect your AI client → OpenAI Codex CLI](/developers/ai/mcp#connect-your-ai-client))
+
+<Steps>
+  <Step title="Clone and install the signing scripts">
+    ```bash
+    git clone https://github.com/gardenfi/garden-agent.git
+    cd garden-agent/garden-skill && bun install
+    ```
+  </Step>
+  <Step title="Store your private key in macOS Keychain">
+    Run the same setup script used by Claude Code:
+
+    ```bash
+    bash ~/garden-agent/garden-skill/scripts/setup-credentials.sh
+    ```
+
+    Codex retrieves the key at swap time via:
+
+    ```bash
+    security find-generic-password -a garden -s garden-pk -w
+    ```
+  </Step>
+  <Step title="Start a session with the skill instructions">
+    ```bash
+    codex --instructions "$(cat ~/garden-agent/garden-skill/SKILL.md)"
+    ```
+
+    Check `codex --help` if the flag name differs in your version.
+  </Step>
+  <Step title="Describe your swap">
+    ```
+    swap 0.001 BTC to wBTC
+    bridge my wBTC to Bitcoin on mainnet
+    ```
+
+    Codex will call the MCP tools and execute the signing scripts to complete the swap end-to-end.
+  </Step>
+</Steps>
+
+---
+
+## Why the experience differs from Claude Code
+
+| Capability | Claude Code | Gemini CLI / Codex CLI |
+|---|---|---|
+| Skill auto-loads | Yes — drop files in `~/.claude/skills/garden/` | No — pass `SKILL.md` manually each session |
+| Private key storage | macOS Keychain (never in environment) | macOS Keychain — same `setup-credentials.sh` script |
+| MCP auto-registration | Yes — skill registers servers on first run | No — configure MCP upfront |
+| Signing scripts | Same Bun scripts, identical behaviour | Same Bun scripts, identical behaviour |
+
+---
+
+## Installation
+
+**Prerequisites**
+
+- [Claude Code](https://claude.ai/code) installed and authenticated
+- [Bun](https://bun.sh) runtime — `curl -fsSL https://bun.sh/install | bash`
+
+**Steps**
+
+<Steps>
+  <Step title="Clone the repository">
+    ```bash
+    git clone https://github.com/gardenfi/garden-agent.git
+    cd garden-agent/garden-skill
+    ```
+  </Step>
+  <Step title="Copy the skill to Claude Code's skills directory">
+    The directory name must be exactly `garden`:
+
+    ```bash
+    cp -r . ~/.claude/skills/garden
+    ```
+  </Step>
+  <Step title="Install dependencies">
+    ```bash
+    cd ~/.claude/skills/garden && bun install
+    ```
+  </Step>
+  <Step title="Restart Claude Code">
+    Quit and reopen Claude Code. The skill is now active.
+  </Step>
+</Steps>
+
+**Updating the skill**
+
+```bash
+cd garden-agent/garden-skill
+git pull
+cp -r . ~/.claude/skills/garden
+cd ~/.claude/skills/garden && bun install
+```
+
+---
+
+## Usage
+
+Describe your swap in plain language inside any Claude Code conversation — no slash command needed:
+
+```
+swap 0.001 wBTC to BTC
+bridge my wBTC to bitcoin
+swap 0.5 SOL to BTC on Garden
+convert 0.0005 BTC to wBTC on testnet
+```
+
+**First-time setup (runs once)**
+
+When you trigger a swap for the first time, the skill will:
+
+1. **Register the Garden MCP servers** if they aren't already connected, then ask you to restart Claude Code.
+2. **Run the credential setup script** to capture your private key — it is stored directly in macOS Keychain and never appears in the conversation.
+
+After the one-time setup, subsequent swaps require no extra steps.
+
+---
+
+---
+
+## Supported swap directions
+
+| From | To | Source chain |
+|---|---|---|
+| BTC | wBTC | Bitcoin |
+| wBTC | BTC | Ethereum (EVM) |
+| SOL / SPL tokens | BTC, wBTC, Starknet assets | Solana |
+| STRK / ETH / wBTC | BTC, wBTC, Solana assets | Starknet |
+| BTC, wBTC | SOL / SPL tokens | Bitcoin / EVM |
+| BTC, wBTC | STRK / ETH / wBTC | Bitcoin / EVM |
+
+All chains derive addresses from a single `GARDEN_PRIVATE_KEY`:
+
+| Chain | Derivation |
+|---|---|
+| EVM | secp256k1 → Ethereum address |
+| Bitcoin | secp256k1 → P2TR taproot address |
+| Solana | 32-byte key as ed25519 seed → base58 pubkey |
+| Starknet | Key as STARK private key → OpenZeppelin account address |
+
+---
+
+## How it works
+
+When you describe a swap, the skill follows this sequence:
+
+<Steps>
+  <Step title="Verify MCP connectivity">
+    Checks that `mcp__garden-mainnet__get_quote` is available. If not, registers the MCP servers and prompts you to restart Claude Code.
+  </Step>
+  <Step title="Collect credentials">
+    Reads saved config from `~/.claude/skills/garden/config.json` and loads your private key from macOS Keychain. Only asks for missing values.
+  </Step>
+  <Step title="Get a quote">
+    Calls `get_quote` with your source asset, destination asset, and amount. Displays the expected receive amount and solver.
+  </Step>
+  <Step title="Confirm">
+    Shows the quote summary and waits for your approval before proceeding.
+  </Step>
+  <Step title="Create the order">
+    Calls `create_order` with the quoted amounts. Receives an `order_id` and deposit instructions.
+  </Step>
+  <Step title="Execute on-chain">
+    Sends the source-chain transaction. The exact method depends on the source chain:
+    - **EVM source** — broadcasts approval + initiate transactions via the bundled signing scripts
+    - **Bitcoin source** — sends BTC to the HTLC deposit address via the bundled Bitcoin script
+    - **Solana source** — signs and broadcasts a versioned transaction
+    - **Starknet source** — auto-deploys the OZ account if needed, then broadcasts approval + initiate
+  </Step>
+  <Step title="Poll for completion">
+    Calls `get_order_status` periodically and reports progress until `destination_swap.redeem_tx_hash` is set.
+  </Step>
+</Steps>
+
+---
+
+## Asset identifiers
+
+The skill resolves common names automatically, but you can be explicit:
+
+| Asset | Mainnet | Testnet |
+|---|---|---|
+| BTC | `bitcoin:btc` | `bitcoin_testnet:btc` |
+| wBTC (Ethereum) | `ethereum:wbtc` | `ethereum_sepolia:wbtc` |
+| SOL | `solana:sol` | `solana_testnet:sol` |
+| USDC (Solana) | `solana:usdc` | `solana_testnet:usdc` |
+| STRK | `starknet:strk` | `starknet_sepolia:strk` |
+| ETH (Starknet) | `starknet:eth` | `starknet_sepolia:eth` |
+| wBTC (Starknet) | `starknet:wbtc` | `starknet_sepolia:wbtc` |
+
+---
+
+## Credential management
+
+Sensitive values are kept out of the conversation entirely:
+
+| Value | Storage |
+|---|---|
+| Private key | macOS Keychain (`security find-generic-password`) |
+| RPC URLs, addresses | `~/.claude/skills/garden/config.json` |
+
+The skill never prints your private key. It is fetched live from Keychain only at the moment it is needed for signing, and only by the bundled scripts.
+
+---
+
+## Completion timeouts
+
+The skill stops polling and reports the `order_id` for manual tracking if these timeouts are reached:
+
+| Source chain | Timeout |
+|---|---|
+| EVM (wBTC) | 5 minutes |
+| Bitcoin | 60 minutes |
+| Solana | 2 minutes |
+| Starknet | 5 minutes |
+
+Bitcoin confirmations on mainnet typically take 10–20 minutes. Testnet blocks are mined very slowly — a BTC-source testnet order can take up to an hour. This is normal.
+
+---
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Garden MCP Server" icon="server" href="/developers/ai/mcp">
+    Connect the MCP server that powers this skill.
+  </Card>
+  <Card title="Integration Skill" icon="code" href="/developers/ai/integration-skill">
+    Add Bitcoin swap support to your own application.
+  </Card>
+</CardGroup>

--- a/developers/ai/integration-skill.mdx
+++ b/developers/ai/integration-skill.mdx
@@ -1,0 +1,236 @@
+---
+title: "Garden Integration Skill"
+description: "Let Claude Code investigate your codebase and build a complete Garden Finance integration"
+---
+
+The **Garden Integration Skill** is a Claude Code skill that adds Bitcoin onramp and offramp support to an existing application. It reads your codebase, finds the right integration point, presents a concrete plan, waits for your approval, and then writes the code.
+
+Tell Claude Code what you want:
+
+> *"Add Garden Finance to my app"*
+> *"Integrate cross-chain BTC swaps into this DEX"*
+> *"Build a Bitcoin onramp for my wallet"*
+
+---
+
+## What it covers
+
+<CardGroup cols={2}>
+  <Card title="React + wagmi" icon="react">
+    Uses `@gardenfi/react-hooks` with `GardenProvider` and `useGarden()`. Handles wallet connection, WASM polyfills, and multi-leg routing.
+  </Card>
+  <Card title="Node.js" icon="node-js">
+    Uses `@gardenfi/core` with `Garden.fromWallets()` and `garden.createSwap()`. Full server-side order lifecycle management.
+  </Card>
+  <Card title="Vue / Svelte / Angular" icon="code">
+    Raw REST API — no new wallet dependencies. Works with any framework via direct HTTP calls to Garden's endpoints.
+  </Card>
+  <Card title="React without wagmi" icon="circle-question">
+    Asks whether to add wagmi (full SDK path) or use the raw REST API (no migration needed). You choose.
+  </Card>
+</CardGroup>
+
+---
+
+## How it works
+
+The skill follows a strict three-phase process. No code is written until you have reviewed and approved the plan.
+
+<Steps>
+  <Step title="Phase 0 — Investigate">
+
+    The skill reads your codebase before proposing anything:
+
+    - **Detects the framework** — React, Node.js, Vue, Svelte, or other
+    - **Identifies the dApp type** — DEX, bridge, wallet, lending, etc.
+    - **Reads the wallet stack** — wagmi, ethers.js, window.ethereum, etc.
+    - **Checks for existing DEX integrations** — searches for an MCP server or official docs for any DEX found
+    - **Finds the bridge asset** — fetches Garden's live asset list and cross-references it with your token config; verifies contract addresses match and makes a live quote call to confirm liquidity before declaring a bridge asset
+
+  </Step>
+  <Step title="Phase 1 — Present the plan">
+
+    Before writing a single line of code, the skill presents a complete integration plan that covers:
+
+    - What your app currently is and how Garden fits in
+    - The bridge asset that connects Garden and your existing tokens
+    - The Bitcoin onramp flow (BTC → your app)
+    - Where Bitcoin will appear in your UI — inside the existing swap component or as a separate widget
+    - Whether to also add wBTC (EVM source) for fast testnet testing (~20 seconds vs ~10 minutes)
+    - The reverse offramp flow (any token → BTC) as a follow-up option
+
+    **You must approve the plan before the skill writes any code.** If you have questions, ask — the skill answers and re-confirms before proceeding.
+
+  </Step>
+  <Step title="Phase 2 — Implement">
+
+    Once approved, the skill writes the integration following your existing code style:
+
+    - Uses the wallet library already in your codebase — no second wallet library
+    - Follows your existing config and environment variable patterns
+    - Places Garden utilities alongside your existing swap utilities
+    - For DEX integrations (Option A): chains Garden and DEX quotes, handles two-legged execution, and leaves all non-BTC token pairs untouched
+    - Implements order history so users can track swaps after a page refresh
+
+  </Step>
+</Steps>
+
+---
+
+## Integration paths
+
+### Path A — React SDK (`@gardenfi/react-hooks`)
+
+For React apps with wagmi. The skill installs dependencies, applies required WASM polyfills, wraps the app with `GardenProvider`, and implements the swap using `useGarden()`.
+
+```tsx
+import { useGarden } from '@gardenfi/react-hooks';
+import { Assets } from '@gardenfi/orderbook';
+
+const { swap, getQuote } = useGarden();
+
+const quote = await getQuote({
+  fromAsset: Assets.bitcoin_testnet.BTC,
+  toAsset:   Assets.arbitrum_sepolia.WBTC,
+  amount:    100000, // satoshis
+  isExactOut: false,
+});
+
+const order = await swap({
+  fromAsset,
+  toAsset,
+  sendAmount:         '100000',
+  receiveAmount:      quote.val[0].destination.amount,
+  solverId:           quote.val[0].solver_id,
+  sourceAddress:      btcAddress,
+  destinationAddress: evmAddress,
+});
+// order.val is the Bitcoin deposit address
+```
+
+### Path B — Node.js SDK (`@gardenfi/core`)
+
+For server-side applications. The skill sets up `Garden.fromWallets()` with a viem wallet client and calls `garden.createSwap()`.
+
+```typescript
+import { Garden } from '@gardenfi/core';
+import { Assets, ChainAsset } from '@gardenfi/orderbook';
+
+const garden = Garden.fromWallets({
+  environment: Network.TESTNET,
+  apiKey:      process.env.GARDEN_API_KEY!,
+  wallets:     { evm: walletClient },
+});
+
+const result = await garden.createSwap({
+  fromAsset:          ChainAsset.from(Assets.bitcoin_testnet.BTC),
+  toAsset:            ChainAsset.from(Assets.arbitrum_sepolia.WBTC),
+  sendAmount:         '100000',
+  receiveAmount:      receiveAmount,
+  solverId:           solverId,
+  sourceAddress:      userBtcAddress,
+  destinationAddress: account.address,
+});
+```
+
+### Path C — Raw REST API
+
+For Vue, Svelte, Angular, and any other framework. The skill calls Garden's HTTP endpoints directly — no SDK, no new wallet dependencies.
+
+```typescript
+// 1. Get a quote
+const quote = await fetch(
+  `${BASE_URL}/quote?from=bitcoin_testnet:btc&to=ethereum_sepolia:wbtc&from_amount=100000&indicative=true`,
+  { headers: { 'garden-app-id': APP_ID } }
+).then(r => r.json());
+
+// 2. Create an order
+const order = await fetch(`${BASE_URL}/orders`, {
+  method: 'POST',
+  headers: { 'garden-app-id': APP_ID, 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    source:      { asset: 'bitcoin_testnet:btc', owner: btcAddress, amount: '100000', delegate: null },
+    destination: { asset: 'ethereum_sepolia:wbtc', owner: evmAddress, amount: quote.result[0].destination.amount, delegate: null },
+    nonce:       Date.now(),
+    solver_id:   quote.result[0].solver_id,
+    slippage:    0,
+  }),
+}).then(r => r.json());
+
+// order.result.to is the Bitcoin deposit address
+```
+
+---
+
+## Multi-leg routing (DEX integration)
+
+When Garden is embedded inside an existing swap component, the skill implements two-legged routing so users can swap BTC directly to any token your DEX supports:
+
+| Source | Destination | Execution |
+|---|---|---|
+| BTC or wBTC | ETH / bridge asset | Garden only — single leg |
+| BTC or wBTC | Any other DEX token | Garden (BTC → ETH) + DEX (ETH → token) |
+| Any other token | Any other token | Existing DEX path — untouched |
+
+Quote chaining: Garden quote → `destination.amount` (ETH) → DEX quote (ETH → buyToken) → display final output. The DEX quote is always re-fetched before execution because Garden's settlement takes minutes and the original quote is stale by then.
+
+---
+
+## Order status and polling
+
+The skill implements a complete status model that covers all terminal states — not just success:
+
+```typescript
+type OrderPhase =
+  | 'awaiting_deposit'
+  | 'deposit_detected'   // confirmations < required
+  | 'confirmed'
+  | 'solver_working'
+  | 'complete'
+  | 'refunded'           // BTC returned to source address
+  | 'expired';           // timed out before deposit detected
+```
+
+
+---
+
+## App ID
+
+All API calls require a Garden App ID sent as the `garden-app-id` header. The skill uses a placeholder and never blocks on it — get your App ID from the [Garden Portal](https://portal.garden.finance) while the integration is being built.
+
+In code, the skill always pulls it from an environment variable:
+
+```
+GARDEN_API_KEY=<your-app-id>              # Node.js / server
+VITE_GARDEN_API_KEY=<your-app-id>         # Vite React
+NEXT_PUBLIC_GARDEN_API_KEY=<your-app-id>  # Next.js React
+```
+
+---
+
+## Common errors
+
+| Error | Cause | Fix |
+|---|---|---|
+| `"No order pair found"` | Token address used as asset ID instead of `id` field | Use only the `id` field from `GET /v2/assets` |
+| `"No quotes available"` | Amount outside min/max, or no solver coverage for the pair | Check `min_amount`/`max_amount`; verify asset pair is active |
+| `"Gas sponsorship is not enabled"` | Called `PATCH ?action=initiate` without sponsorship | Use direct on-chain transactions (approval + initiate) |
+
+---
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="SDK Overview" icon="book-open" href="/developers/sdk/overview">
+    Full reference for the React and Node.js SDKs.
+  </Card>
+  <Card title="API Reference" icon="code-simple" href="/api-reference/quickstart">
+    Complete HTTP endpoint documentation.
+  </Card>
+  <Card title="Order Lifecycle" icon="arrows-spin" href="/developers/core/order-lifecycle">
+    All order statuses and state transitions.
+  </Card>
+  <Card title="Garden MCP Server" icon="server" href="/developers/ai/mcp">
+    The MCP server powering live API calls during integration.
+  </Card>
+</CardGroup>

--- a/developers/ai/mcp.mdx
+++ b/developers/ai/mcp.mdx
@@ -1,0 +1,398 @@
+---
+title: "Garden MCP Server"
+description: "Remote MCP server that gives AI assistants direct access to Garden Finance's swap API"
+---
+
+The Garden MCP server exposes Garden's swap functionality as [Model Context Protocol](https://modelcontextprotocol.io) tools. Connect any MCP-compatible AI client — Claude Code, Claude Desktop, Cursor, Windsurf, ChatGPT Desktop, Codex CLI, Gemini CLI — and let it get quotes, create orders, and track swaps in real time.
+
+The server is hosted and publicly available. No local setup or API key required to connect.
+
+<Note>
+  The MCP server handles quoting and order creation, but **signing and initiating transactions requires your external wallet** — the server never holds your keys. If you want fully automated end-to-end swaps (quote → sign → initiate → poll), use the [Garden Swap Skill](/developers/ai/garden-skill) instead, which manages the full lifecycle including on-chain signing from Claude Code.
+</Note>
+
+---
+
+## Available tools
+
+| Tool | Description |
+|---|---|
+| `get_quote` | Get a swap quote between two assets — returns destination amount, fees, solver, and estimated time |
+| `create_order` | Submit a cross-chain swap order using amounts from a prior quote |
+| `get_order_status` | Get the current status of an order by ID |
+| `get_all_user_orders` | List all orders for a wallet address, with optional chain and status filters |
+| `get_assets` | List all supported assets available for swapping |
+| `get_chains` | List all supported blockchain networks |
+| `get_liquidity` | Get real-time liquidity information across all chains |
+
+---
+
+## Hosted endpoints
+
+| Network | MCP URL |
+|---|---|
+| Mainnet | `https://mainnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp` |
+| Testnet | `https://testnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp` |
+
+---
+
+## Connect your AI client
+
+<AccordionGroup>
+  <Accordion title="Claude Code" icon="terminal">
+
+<Tabs>
+  <Tab title="CLI (recommended)">
+
+Run one command per network — Claude Code adds the server to your global config automatically:
+
+```bash
+# Mainnet
+claude mcp add --transport http garden-mainnet \
+  https://mainnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp
+
+# Testnet
+claude mcp add --transport http garden-testnet \
+  https://testnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp
+```
+
+  </Tab>
+  <Tab title="settings.json">
+
+Add to `.claude/settings.json` (project-level) or `~/.claude/settings.json` (global):
+
+```json
+{
+  "mcpServers": {
+    "garden-mainnet": {
+      "type": "http",
+      "url": "https://mainnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp"
+    },
+    "garden-testnet": {
+      "type": "http",
+      "url": "https://testnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp"
+    }
+  }
+}
+```
+
+  </Tab>
+</Tabs>
+
+Verify the connection:
+
+```bash
+claude mcp list
+```
+
+You should see `garden-mainnet` and `garden-testnet` listed as connected servers.
+
+  </Accordion>
+
+  <Accordion title="Claude Desktop" icon="desktop">
+
+<Steps>
+  <Step title="Open the config file">
+    The config file location depends on your OS:
+
+    | OS | Path |
+    |---|---|
+    | macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+    | Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+
+    Create the file if it doesn't exist.
+  </Step>
+  <Step title="Add the Garden MCP server">
+    ```json
+    {
+      "mcpServers": {
+        "garden-mainnet": {
+          "type": "http",
+          "url": "https://mainnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp"
+        },
+        "garden-testnet": {
+          "type": "http",
+          "url": "https://testnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp"
+        }
+      }
+    }
+    ```
+
+    If the file already has other `mcpServers` entries, merge the Garden keys into the existing object.
+  </Step>
+  <Step title="Restart Claude Desktop">
+    Quit and reopen Claude Desktop. The Garden tools will appear in the tool picker when you start a conversation.
+  </Step>
+</Steps>
+
+  </Accordion>
+
+  <Accordion title="Cursor" icon="mouse-pointer">
+
+<Tabs>
+  <Tab title="Settings UI">
+
+<Steps>
+  <Step title="Open MCP settings">
+    Go to **Cursor Settings** (⌘, on macOS) → **MCP** → **+ Add new MCP server**.
+  </Step>
+  <Step title="Enter the server details">
+    | Field | Value |
+    |---|---|
+    | Name | `garden-mainnet` |
+    | Type | `HTTP` |
+    | URL | `https://mainnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp` |
+  </Step>
+  <Step title="Save and verify">
+    Click **Save**. Cursor will connect and display the available Garden tools.
+  </Step>
+</Steps>
+
+  </Tab>
+  <Tab title="mcp.json">
+
+Add to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project-local):
+
+```json
+{
+  "mcpServers": {
+    "garden-mainnet": {
+      "url": "https://mainnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp"
+    },
+    "garden-testnet": {
+      "url": "https://testnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp"
+    }
+  }
+}
+```
+
+Restart Cursor after saving.
+
+  </Tab>
+</Tabs>
+
+  </Accordion>
+
+  <Accordion title="Windsurf" icon="wind">
+
+<Steps>
+  <Step title="Open the MCP config file">
+    Open `~/.codeium/windsurf/mcp_config.json`. Create it if it doesn't exist.
+  </Step>
+  <Step title="Add the Garden MCP server">
+    ```json
+    {
+      "mcpServers": {
+        "garden-mainnet": {
+          "serverUrl": "https://mainnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp"
+        },
+        "garden-testnet": {
+          "serverUrl": "https://testnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp"
+        }
+      }
+    }
+    ```
+  </Step>
+  <Step title="Restart Windsurf">
+    Reopen Windsurf. The Garden tools will be available in Cascade.
+  </Step>
+</Steps>
+
+  </Accordion>
+
+  <Accordion title="ChatGPT Desktop" icon="comment">
+
+<Steps>
+  <Step title="Open Settings">
+    In the ChatGPT desktop app, click your profile icon → **Settings** → **Connectors**.
+  </Step>
+  <Step title="Add an MCP server">
+    Click **+ Add MCP Server** and fill in:
+
+    | Field | Value |
+    |---|---|
+    | Name | `Garden Finance` |
+    | URL | `https://mainnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp` |
+  </Step>
+  <Step title="Enable and verify">
+    Toggle the server on. Start a new conversation and verify that Garden tools appear when you mention swapping assets.
+  </Step>
+</Steps>
+
+<Note>
+  MCP support in ChatGPT Desktop is available on macOS. Check [OpenAI's documentation](https://help.openai.com) for the latest availability on other platforms.
+</Note>
+
+  </Accordion>
+
+  <Accordion title="OpenAI Codex CLI" icon="code">
+
+<Steps>
+  <Step title="Open the Codex config file">
+    Open `~/.codex/config.toml`. Create it if it doesn't exist.
+  </Step>
+  <Step title="Add the Garden MCP server">
+    ```toml
+    [[mcp_servers]]
+    name = "garden-mainnet"
+    url  = "https://mainnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp"
+
+    [[mcp_servers]]
+    name = "garden-testnet"
+    url  = "https://testnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp"
+    ```
+  </Step>
+  <Step title="Verify the connection">
+    Run `codex` and ask it to list available tools — the Garden tools (`get_quote`, `create_order`, etc.) should appear.
+  </Step>
+</Steps>
+
+  </Accordion>
+
+  <Accordion title="Gemini CLI" icon="google">
+
+<Steps>
+  <Step title="Open the Gemini settings file">
+    Open `~/.gemini/settings.json`. Create it if it doesn't exist.
+  </Step>
+  <Step title="Add the Garden MCP server">
+    ```json
+    {
+      "mcpServers": {
+        "garden-mainnet": {
+          "url": "https://mainnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp"
+        },
+        "garden-testnet": {
+          "url": "https://testnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp"
+        }
+      }
+    }
+    ```
+  </Step>
+  <Step title="Verify the connection">
+    Start a new `gemini` session. The Garden tools will be listed alongside any other configured MCP tools.
+  </Step>
+</Steps>
+
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Run locally
+
+If you want to self-host the MCP server (for custom App IDs, private deployments, or development):
+
+<Tabs>
+  <Tab title="Bun">
+
+**Prerequisites:** [Bun](https://bun.sh) v1.x
+
+```bash
+git clone https://github.com/gardenfi/garden-agent
+cd garden-agent/garden-mcp
+bun install
+
+# Mainnet
+BASE_URL=https://api.garden.finance/v2 \
+APP_ID=your_app_id \
+bun run index.ts
+
+# Testnet
+BASE_URL=https://testnet.api.garden.finance/v2 \
+APP_ID=your_app_id \
+bun run index.ts
+```
+
+Connect Claude Code to the local instance:
+
+```bash
+claude mcp add --transport http garden-local http://localhost:3000/mcp
+```
+
+  </Tab>
+  <Tab title="Docker Compose">
+
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/)
+
+```bash
+cd garden-agent/garden-mcp
+docker compose up --build
+```
+
+This starts mainnet on port `3001` and testnet on port `3002`:
+
+```bash
+claude mcp add --transport http garden-mainnet http://localhost:3001/mcp
+claude mcp add --transport http garden-testnet http://localhost:3002/mcp
+```
+
+  </Tab>
+</Tabs>
+
+### Environment variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `BASE_URL` | Yes | — | Garden API base URL (`https://api.garden.finance/v2` or testnet equivalent) |
+| `APP_ID` | Yes | — | Your Garden App ID |
+| `PORT` | No | `3000` | Port to listen on |
+
+Get an App ID from the [Garden Portal](https://portal.garden.finance).
+
+---
+
+## Deploy on Coolify
+
+<Steps>
+  <Step title="Fork the repository">
+    Fork or push `garden-agent/garden-mcp` to GitHub.
+  </Step>
+  <Step title="Create a new resource">
+    In Coolify: **New Resource → Docker Compose** → connect your repository.
+  </Step>
+  <Step title="Set environment variables">
+    | Variable | Value |
+    |---|---|
+    | `BASE_URL` | `https://api.garden.finance/v2` (mainnet) or testnet equivalent |
+    | `APP_ID` | Your Garden App ID |
+    | `PORT` | `3000` |
+  </Step>
+  <Step title="Point DNS">
+    Create a DNS record: `mcp.yourdomain.com` → your Coolify service.
+  </Step>
+  <Step title="Share the URL">
+    Users connect with `claude mcp add --transport http garden https://mcp.yourdomain.com/mcp` — no local setup needed.
+  </Step>
+</Steps>
+
+A health check endpoint at `GET /health` is built in — Coolify uses it to verify the service is running.
+
+---
+
+## Architecture
+
+The server uses the [MCP Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) in **stateless mode**. Each request creates a fresh server instance, which works well here because all tools are pure API proxies with no session state.
+
+```
+MCP Client (Claude Code, Cursor, …)
+        │  POST /mcp
+        ▼
+  garden-mcp  (Express + StreamableHTTPServerTransport)
+        │
+        ▼
+  Garden Finance API  (api.garden.finance / testnet.api.garden.finance)
+```
+
+---
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Garden Swap Skill" icon="wand-magic-sparkles" href="/developers/ai/garden-skill">
+    Once the MCP server is connected, use the Garden Swap Skill to execute swaps from natural language.
+  </Card>
+  <Card title="Integration Skill" icon="code" href="/developers/ai/integration-skill">
+    Let Claude Code build a complete Garden integration into your existing application.
+  </Card>
+</CardGroup>

--- a/developers/ai/overview.mdx
+++ b/developers/ai/overview.mdx
@@ -1,0 +1,67 @@
+---
+title: "AI & Agents Overview"
+description: "Use Garden Finance with AI assistants and Claude Code through MCP and skills"
+---
+
+Garden ships three components that bring cross-chain swaps into AI workflows:
+
+<CardGroup cols={3}>
+  <Card title="Garden MCP" icon="server" href="/developers/ai/mcp">
+    A remote MCP server that gives any AI assistant direct access to Garden's swap API — no local setup required.
+  </Card>
+  <Card title="Garden Swap Skill" icon="wand-magic-sparkles" href="/developers/ai/garden-skill">
+    A Claude Code skill that lets you perform cross-chain swaps by describing them in plain language.
+  </Card>
+  <Card title="Integration Skill" icon="code" href="/developers/ai/integration-skill">
+    A Claude Code skill that investigates your codebase and builds a complete Garden integration, ready to ship.
+  </Card>
+</CardGroup>
+
+---
+
+## How they fit together
+
+```
++-------------------------------------------------------------+
+|                        Claude Code                          |
+|                                                             |
+|   Garden Swap Skill            Integration Skill            |
+|   (swap BTC -> wBTC)      (add Bitcoin to my app)           |
+|         |                          |                        |
+|         +------------+-------------+                        |
+|                      |                                      |
+|              Garden MCP Server                              |
+|   get_quote  create_order  get_order_status  ...            |
++----------------------+--------------------------------------+
+                       |
+              Garden Finance API
+        (mainnet.api.garden.finance)
+```
+
+| Component | Who uses it | What it does |
+|---|---|---|
+| **Garden MCP** | Any MCP-compatible AI client | Exposes Garden API as callable tools |
+| **Garden Swap Skill** | Claude Code end-users | Executes swaps from a natural-language request |
+| **Integration Skill** | Claude Code developers | Integrates Garden into an existing codebase |
+
+---
+
+## Quick start
+
+Connect the MCP server to Claude Code in one command, then ask it to swap:
+
+```bash
+claude mcp add --transport http garden-mainnet \
+  https://mainnet-eq28f5912wbhjad5b5zpyikt.garden-staging.dealpulley.com/mcp
+```
+
+Once connected, the **Garden Swap Skill** activates automatically when you describe a swap in Claude Code.
+
+<CardGroup cols={2}>
+  <Card title="MCP Server" icon="plug" href="/developers/ai/mcp">
+    Connect Claude Code, Cursor, or any MCP client.
+  </Card>
+  <Card title="Garden Swap Skill" icon="bolt" href="/developers/ai/garden-skill">
+    Swap BTC ↔ wBTC and more from the command line.
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -165,6 +165,15 @@
             ]
           },
           {
+            "group": "AI & Agents",
+            "pages": [
+              "developers/ai/overview",
+              "developers/ai/mcp",
+              "developers/ai/garden-skill",
+              "developers/ai/integration-skill"
+            ]
+          },
+          {
             "group": "Testing",
             "pages": [
               "developers/localnet"


### PR DESCRIPTION
Adds a new "AI & Agents" documentation group covering Garden's MCP server, the garden swap skill, and the SDK integration skill for developers.